### PR TITLE
[PR] Add support for more alternate names, force TLS

### DIFF
--- a/config/multi-site-nginx-block.conf
+++ b/config/multi-site-nginx-block.conf
@@ -2,6 +2,12 @@
 #
 # Generated <% config_generated %> by <% config_creator %>
 server {
+    listen 80;
+    server_name <% cert_domain %> <% alt_domains %>;
+    return 301 https://<% cert_domain %>$request_uri;
+}
+
+server {
     listen 443 ssl spdy;
     server_name <% alt_domains %>;
 

--- a/config/multi-site-nginx-block.conf
+++ b/config/multi-site-nginx-block.conf
@@ -3,7 +3,7 @@
 # Generated <% config_generated %> by <% config_creator %>
 server {
     listen 443 ssl spdy;
-    server_name www.<% cert_domain %>;
+    server_name <% alt_domains %>;
 
     ssl on;
     ssl_certificate     /etc/nginx/ssl/<% cert_domain %>.cer;

--- a/config/single-site-nginx-block.conf
+++ b/config/single-site-nginx-block.conf
@@ -2,6 +2,12 @@
 #
 # Generated <% config_generated %> by <% config_creator %>
 server {
+    listen 80;
+    server_name <% cert_domain %>;
+    return 301 https://<% cert_domain %>$request_uri;
+}
+
+server {
     listen 443 ssl spdy;
     server_name <% cert_domain %>;
     root /var/www/wordpress;

--- a/wsuwp-tls.php
+++ b/wsuwp-tls.php
@@ -274,12 +274,21 @@ class WSUWP_TLS {
 						$server_block_config = str_replace( '<% cert_domain %>', $new_cert_domain, $server_block_config );
 						$server_block_config = str_replace( '<% config_generated %>', date('Y-m-d H:i:s' ), $server_block_config );
 						$server_block_config = str_replace( '<% config_creator %>', $config_user->user_login, $server_block_config );
-					} elseif ( 2 === count( $new_cert_alt_names ) ) {
+					} elseif ( 2 <= count( $new_cert_alt_names ) ) {
 						$server_block_config = file_get_contents( dirname( __FILE__ ) . '/config/multi-site-nginx-block.conf' );
+						// Remove the primary CN domain from the list of alternate names.
+						foreach( $new_cert_alt_names as $k => $v ) {
+							if ( $v === $new_cert_domain ) {
+								unset( $new_cert_alt_names[ $k ] );
+							}
+						}
+						$new_cert_alt_names = implode( ' ', $new_cert_alt_names );
+						$server_block_config = str_replace( '<% alt_domains %>', $new_cert_alt_names, $server_block_config );
 						$server_block_config = str_replace( '<% cert_domain %>', $new_cert_domain, $server_block_config );
 						$server_block_config = str_replace( '<% config_generated %>', date('Y-m-d H:i:s' ), $server_block_config );
 						$server_block_config = str_replace( '<% config_creator %>', $config_user->user_login, $server_block_config );
 					} else {
+						// Should only throw this error when 0 domains are passed for subjectAltName.
 						wp_die( 'The number of subjectAltName values in this certificate is invalid.' );
 						exit;
 					}


### PR DESCRIPTION
* Support certificates that specify more than 2 subjectAltNames
* Force all HTTP 80 requests for domains configured through WSUWP TLS to HTTPS 443.