### PR TITLE
[PR] Use `get_main_network_id()` to check for the main network

### DIFF
--- a/wsuwp-tls.php
+++ b/wsuwp-tls.php
@@ -172,7 +172,7 @@ class WSUWP_TLS {
 	public function tls_admin_menu( $parent_file ) {
 		global $self, $submenu, $submenu_file;
 
-		if ( wsuwp_get_current_network()->id == wsuwp_get_primary_network_id() ) {
+		if ( wsuwp_get_current_network()->id == get_main_network_id() ) {
 			$submenu['sites.php'][15] = array(
 				'Manage Site TLS',
 				'manage_sites',


### PR DESCRIPTION
In WordPress 4.3.0, we introduced `get_main_network_id()`, which
is an exact replacement for the old wsuwp_get_primary_network_id()
that was provided in the WSUWP Platform. This is being removed
in WSUWP and we can no longer rely on it here